### PR TITLE
Hotfix: merge currentLocation

### DIFF
--- a/src/app/login/login.service.ts
+++ b/src/app/login/login.service.ts
@@ -13,9 +13,7 @@ import { CookieService } from './cookie.service';
 })
 export class LoginService {
   Jwttoken: any;
-  wrongPassWordChange: Subject<boolean> = new Subject<boolean>;
   username: string = '';
-  constructor(private http: HttpClient, private router: Router, ) {}
   wrongPassWordChange: Subject<boolean> = new Subject<boolean>();
   constructor(
     private http: HttpClient,

--- a/src/app/services/data-storage.service.ts
+++ b/src/app/services/data-storage.service.ts
@@ -2,11 +2,10 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Location } from '../interfaces/location';
 import { Packaging } from '../interfaces/packaging';
-import { Subject, tap, forkJoin, Observable } from 'rxjs';
+import { Subject, forkJoin, Observable } from 'rxjs';
 import { Stock } from '../interfaces/stock';
 import { InventoryData } from '../interfaces/InventoryData.interface';
 import { Account } from '../interfaces/account.interface';
-import { error } from 'console';
 import { ChangeIsPackedRequestData } from '../models/ChangeIsPackedRequestData';
 
 @Injectable({


### PR DESCRIPTION
accidentally messed up with conflict resolving due to having only a few minutes to do so before the review, removed double constructor and a variable that got defined twice